### PR TITLE
fix: changing ball spawning point to avoid context errors

### DIFF
--- a/lib/game/pinball_game.dart
+++ b/lib/game/pinball_game.dart
@@ -18,10 +18,15 @@ class PinballGame extends Forge2DGame with FlameBloc {
 
   @override
   Future<void> onLoad() async {
-    spawnBall();
     addContactCallback(BallScorePointsCallback());
 
     await add(BottomWall(this));
     addContactCallback(BottomWallBallContactCallback());
+  }
+
+  @override
+  void onAttach() {
+    super.onAttach();
+    spawnBall();
   }
 }


### PR DESCRIPTION
## Description

In a task being tackled by @allisonryan0002 , we will need to access a bloc from the `createBody` method of the `Ball` component.

To do so we need to move the addition of the ball on the game from the `onLoad` method to the `onAttach`, because due to how the Flame lifecycle works, the build context is not ready before.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
