### PR TITLE
refactor: removed findNested extensions

### DIFF
--- a/test/game/components/board_test.dart
+++ b/test/game/components/board_test.dart
@@ -30,9 +30,9 @@ void main() {
           await game.ready();
           await game.ensureAdd(board);
 
-          final leftFlippers = board.findNestedChildren<Flipper>(
-            condition: (flipper) => flipper.side.isLeft,
-          );
+          final leftFlippers = board.descendants().whereType<Flipper>().where(
+                (flipper) => flipper.side.isLeft,
+              );
           expect(leftFlippers.length, equals(1));
         },
       );
@@ -43,10 +43,9 @@ void main() {
           final board = Board();
           await game.ready();
           await game.ensureAdd(board);
-
-          final rightFlippers = board.findNestedChildren<Flipper>(
-            condition: (flipper) => flipper.side.isRight,
-          );
+          final rightFlippers = board.descendants().whereType<Flipper>().where(
+                (flipper) => flipper.side.isRight,
+              );
           expect(rightFlippers.length, equals(1));
         },
       );
@@ -58,7 +57,7 @@ void main() {
           await game.ready();
           await game.ensureAdd(board);
 
-          final baseboards = board.findNestedChildren<Baseboard>();
+          final baseboards = board.descendants().whereType<Baseboard>();
           expect(baseboards.length, equals(2));
         },
       );
@@ -70,7 +69,7 @@ void main() {
           await game.ready();
           await game.ensureAdd(board);
 
-          final kickers = board.findNestedChildren<Kicker>();
+          final kickers = board.descendants().whereType<Kicker>();
           expect(kickers.length, equals(2));
         },
       );
@@ -83,7 +82,7 @@ void main() {
           await game.ready();
           await game.ensureAdd(board);
 
-          final roundBumpers = board.findNestedChildren<RoundBumper>();
+          final roundBumpers = board.descendants().whereType<RoundBumper>();
           expect(roundBumpers.length, equals(3));
         },
       );

--- a/test/helpers/extensions.dart
+++ b/test/helpers/extensions.dart
@@ -1,4 +1,3 @@
-import 'package:flame/components.dart';
 import 'package:pinball/game/game.dart';
 import 'package:pinball_theme/pinball_theme.dart';
 
@@ -20,42 +19,4 @@ extension DebugPinballGameTest on DebugPinballGame {
           characterTheme: DashTheme(),
         ),
       );
-}
-
-extension ComponentX on Component {
-  T findNestedChild<T extends Component>({
-    bool Function(T)? condition,
-  }) {
-    T? nestedChild;
-    propagateToChildren<T>((child) {
-      final foundChild = (condition ?? (_) => true)(child);
-      if (foundChild) {
-        nestedChild = child;
-      }
-
-      return !foundChild;
-    });
-
-    if (nestedChild == null) {
-      throw Exception('No child of type $T found.');
-    } else {
-      return nestedChild!;
-    }
-  }
-
-  List<T> findNestedChildren<T extends Component>({
-    bool Function(T)? condition,
-  }) {
-    final nestedChildren = <T>[];
-    propagateToChildren<T>((child) {
-      final foundChild = (condition ?? (_) => true)(child);
-      if (foundChild) {
-        nestedChildren.add(child);
-      }
-
-      return true;
-    });
-
-    return nestedChildren;
-  }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Removed no longer needed `findNested` extension since the new Flame version includes `descendants`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
