### PR TITLE
fix(leaderboard_repository): sort scores in descending order

### DIFF
--- a/packages/leaderboard_repository/lib/src/leaderboard_repository.dart
+++ b/packages/leaderboard_repository/lib/src/leaderboard_repository.dart
@@ -91,7 +91,7 @@ class LeaderboardRepository {
     try {
       final querySnapshot = await _firebaseFirestore
           .collection('leaderboard')
-          .orderBy('score')
+          .orderBy('score', descending: true)
           .limit(10)
           .get();
       documents = querySnapshot.docs;
@@ -130,7 +130,7 @@ class LeaderboardRepository {
     try {
       final querySnapshot = await _firebaseFirestore
           .collection('leaderboard')
-          .orderBy('score')
+          .orderBy('score', descending: true)
           .get();
 
       // TODO(allisonryan0002): see if we can find a more performant solution.

--- a/packages/leaderboard_repository/test/src/leaderboard_repository_test.dart
+++ b/packages/leaderboard_repository/test/src/leaderboard_repository_test.dart
@@ -82,7 +82,7 @@ void main() {
 
         when(() => firestore.collection('leaderboard'))
             .thenAnswer((_) => collectionReference);
-        when(() => collectionReference.orderBy('score'))
+        when(() => collectionReference.orderBy('score', descending: true))
             .thenAnswer((_) => query);
         when(() => query.limit(10)).thenAnswer((_) => query);
         when(query.get).thenAnswer((_) async => querySnapshot);
@@ -173,7 +173,7 @@ void main() {
             .thenAnswer((_) => collectionReference);
         when(() => collectionReference.add(any()))
             .thenAnswer((_) async => documentReference);
-        when(() => collectionReference.orderBy('score'))
+        when(() => collectionReference.orderBy('score', descending: true))
             .thenAnswer((_) => query);
         when(query.get).thenAnswer((_) async => querySnapshot);
         when(() => querySnapshot.docs).thenReturn(queryDocumentSnapshots);
@@ -203,7 +203,8 @@ void main() {
       test(
           'throws FetchPlayerRankingException when Exception occurs '
           'when trying to retrieve information from firestore', () async {
-        when(() => collectionReference.orderBy('score')).thenThrow(Exception());
+        when(() => collectionReference.orderBy('score', descending: true))
+            .thenThrow(Exception());
 
         expect(
           () => leaderboardRepository.addLeaderboardEntry(leaderboardEntry),


### PR DESCRIPTION
## Description

* realized I missed a pretty important detail - leaderboard scores are now sorted in the proper order

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
