### PR TITLE
refactor: adjust dash bumper body

### DIFF
--- a/packages/pinball_components/lib/src/components/dash_nest_bumper.dart
+++ b/packages/pinball_components/lib/src/components/dash_nest_bumper.dart
@@ -67,6 +67,7 @@ class BigDashNestBumper extends DashNestBumper {
           inactiveAssetPath: Assets.images.dashBumper.main.inactive.keyName,
           spriteComponent: SpriteComponent(
             anchor: Anchor.center,
+            position: Vector2(0, -0.3),
           ),
         );
 
@@ -74,9 +75,9 @@ class BigDashNestBumper extends DashNestBumper {
   Body createBody() {
     final shape = EllipseShape(
       center: Vector2.zero(),
-      majorRadius: 4.85,
-      minorRadius: 3.95,
-    )..rotate(math.pi / 2);
+      majorRadius: 5.1,
+      minorRadius: 3.75,
+    )..rotate(math.pi / 2.1);
     final fixtureDef = FixtureDef(shape);
 
     final bodyDef = BodyDef()

--- a/packages/pinball_components/sandbox/lib/stories/dash_nest_bumper/big.dart
+++ b/packages/pinball_components/sandbox/lib/stories/dash_nest_bumper/big.dart
@@ -23,7 +23,9 @@ class BigDashNestBumperGame extends BasicBallGame {
     await super.onLoad();
 
     final center = screenToWorld(camera.viewport.canvasSize! / 2);
-    final bigDashNestBumper = BigDashNestBumper()..initialPosition = center;
+    final bigDashNestBumper = BigDashNestBumper()
+      ..initialPosition = center
+      ..priority = 1;
     await add(bigDashNestBumper);
 
     if (trace) bigDashNestBumper.trace();


### PR DESCRIPTION
## Description

* adjusts `BigDashNestBumper` body to better fit sprite
* adds priority to sandbox bumper so ball goes behind it

![CleanShot 2022-04-04 at 10 45 07](https://user-images.githubusercontent.com/77211884/161582090-ba876268-60ee-44ba-a2b9-0891c07b4c85.png)

![CleanShot 2022-04-04 at 10 44 50](https://user-images.githubusercontent.com/77211884/161582101-e50f7195-7b77-4907-b4fd-fc1450b5150a.gif)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
