### PR TITLE
chore: trace all bodies in sandbox

### DIFF
--- a/packages/pinball_components/sandbox/lib/common/trace.dart
+++ b/packages/pinball_components/sandbox/lib/common/trace.dart
@@ -26,7 +26,7 @@ extension BodyTrace on BodyComponent {
 }
 
 mixin Traceable on Forge2DGame {
-  bool get trace;
+  late final bool trace;
 
   Future<void> traceAllBodies({
     Color color = const Color(0xFFFF0000),

--- a/packages/pinball_components/sandbox/lib/stories/dash_nest_bumper/big_dash_nest_bumper_game.dart
+++ b/packages/pinball_components/sandbox/lib/stories/dash_nest_bumper/big_dash_nest_bumper_game.dart
@@ -5,18 +5,14 @@ import 'package:pinball_components/pinball_components.dart';
 import 'package:sandbox/common/common.dart';
 import 'package:sandbox/stories/ball/basic_ball_game.dart';
 
-class BigDashNestBumperGame extends BasicBallGame {
-  BigDashNestBumperGame({
-    required this.trace,
-  }) : super(color: const Color(0xFF0000FF));
+class BigDashNestBumperGame extends BasicBallGame with Traceable {
+  BigDashNestBumperGame() : super(color: const Color(0xFF0000FF));
 
   static const info = '''
     Shows how a BigDashNestBumper is rendered.
 
     Activate the "trace" parameter to overlay the body.
 ''';
-
-  final bool trace;
 
   @override
   Future<void> onLoad() async {
@@ -28,6 +24,6 @@ class BigDashNestBumperGame extends BasicBallGame {
       ..priority = 1;
     await add(bigDashNestBumper);
 
-    if (trace) bigDashNestBumper.trace();
+    await traceAllBodies();
   }
 }

--- a/packages/pinball_components/sandbox/lib/stories/dash_nest_bumper/stories.dart
+++ b/packages/pinball_components/sandbox/lib/stories/dash_nest_bumper/stories.dart
@@ -8,9 +8,8 @@ void addDashNestBumperStories(Dashbook dashbook) {
   dashbook.storiesOf('Dash Nest Bumpers').add(
         'Big',
         (context) => GameWidget(
-          game: BigDashNestBumperGame(
-            trace: context.boolProperty('Trace', true),
-          ),
+          game: BigDashNestBumperGame()
+            ..trace = context.boolProperty('Trace', true),
         ),
         codeLink: buildSourceLink('dash_nest_bumper/big.dart'),
         info: BasicBallGame.info,

--- a/packages/pinball_components/sandbox/lib/stories/flipper/flipper_game.dart
+++ b/packages/pinball_components/sandbox/lib/stories/flipper/flipper_game.dart
@@ -7,10 +7,7 @@ import 'package:sandbox/common/common.dart';
 import 'package:sandbox/stories/ball/basic_ball_game.dart';
 
 class FlipperGame extends BasicBallGame with KeyboardEvents, Traceable {
-  FlipperGame({
-    required bool trace,
-  })  : _trace = trace,
-        super(color: Colors.blue);
+  FlipperGame() : super(color: Colors.blue);
 
   static const info = '''
     Shows how Flippers are rendered.
@@ -30,11 +27,6 @@ class FlipperGame extends BasicBallGame with KeyboardEvents, Traceable {
     LogicalKeyboardKey.arrowRight,
     LogicalKeyboardKey.keyD,
   ];
-
-  final bool _trace;
-
-  @override
-  bool get trace => _trace;
 
   late Flipper leftFlipper;
   late Flipper rightFlipper;

--- a/packages/pinball_components/sandbox/lib/stories/flipper/stories.dart
+++ b/packages/pinball_components/sandbox/lib/stories/flipper/stories.dart
@@ -7,9 +7,7 @@ void addFlipperStories(Dashbook dashbook) {
   dashbook.storiesOf('Flipper').add(
         'Basic',
         (context) => GameWidget(
-          game: FlipperGame(
-            trace: context.boolProperty('Trace', true),
-          ),
+          game: FlipperGame()..trace = context.boolProperty('Trace', true),
         ),
         codeLink: buildSourceLink('flipper/basic.dart'),
         info: FlipperGame.info,

--- a/packages/pinball_components/sandbox/lib/stories/kicker/kicker_game.dart
+++ b/packages/pinball_components/sandbox/lib/stories/kicker/kicker_game.dart
@@ -4,10 +4,7 @@ import 'package:sandbox/common/common.dart';
 import 'package:sandbox/stories/ball/basic_ball_game.dart';
 
 class KickerGame extends BasicBallGame with Traceable {
-  KickerGame({
-    required bool trace,
-  })  : _trace = trace,
-        super(color: const Color(0xFFFF0000));
+  KickerGame() : super(color: const Color(0xFFFF0000));
 
   static const info = '''
     Shows how Kickers are rendered.
@@ -15,11 +12,6 @@ class KickerGame extends BasicBallGame with Traceable {
     - Activate the "trace" parameter to overlay the body.
     - Tap anywhere on the screen to spawn a ball into the game.
 ''';
-
-  final bool _trace;
-
-  @override
-  bool get trace => _trace;
 
   @override
   Future<void> onLoad() async {

--- a/packages/pinball_components/sandbox/lib/stories/kicker/stories.dart
+++ b/packages/pinball_components/sandbox/lib/stories/kicker/stories.dart
@@ -7,9 +7,7 @@ void addKickerStories(Dashbook dashbook) {
   dashbook.storiesOf('Kickers').add(
         'Basic',
         (context) => GameWidget(
-          game: KickerGame(
-            trace: context.boolProperty('Trace', true),
-          ),
+          game: KickerGame()..trace = context.boolProperty('Trace', true),
         ),
         codeLink: buildSourceLink('kicker_game/basic.dart'),
         info: KickerGame.info,

--- a/packages/pinball_components/sandbox/lib/stories/slingshot/slingshot_game.dart
+++ b/packages/pinball_components/sandbox/lib/stories/slingshot/slingshot_game.dart
@@ -4,10 +4,7 @@ import 'package:sandbox/common/common.dart';
 import 'package:sandbox/stories/ball/basic_ball_game.dart';
 
 class SlingshotGame extends BasicBallGame with Traceable {
-  SlingshotGame({
-    required bool trace,
-  })  : _trace = trace,
-        super(color: const Color(0xFFFF0000));
+  SlingshotGame() : super(color: const Color(0xFFFF0000));
 
   static const info = '''
     Shows how Slingshots are rendered.
@@ -15,11 +12,6 @@ class SlingshotGame extends BasicBallGame with Traceable {
     - Activate the "trace" parameter to overlay the body.
     - Tap anywhere on the screen to spawn a ball into the game.
 ''';
-
-  final bool _trace;
-
-  @override
-  bool get trace => _trace;
 
   @override
   Future<void> onLoad() async {

--- a/packages/pinball_components/sandbox/lib/stories/slingshot/stories.dart
+++ b/packages/pinball_components/sandbox/lib/stories/slingshot/stories.dart
@@ -7,9 +7,7 @@ void addSlingshotStories(Dashbook dashbook) {
   dashbook.storiesOf('Slingshots').add(
         'Basic',
         (context) => GameWidget(
-          game: SlingshotGame(
-            trace: context.boolProperty('Trace', true),
-          ),
+          game: SlingshotGame()..trace = context.boolProperty('Trace', true),
         ),
         codeLink: buildSourceLink('slingshot_game/basic.dart'),
         info: SlingshotGame.info,

--- a/packages/pinball_components/sandbox/lib/stories/sparky_bumper/sparky_bumper_game.dart
+++ b/packages/pinball_components/sandbox/lib/stories/sparky_bumper/sparky_bumper_game.dart
@@ -6,21 +6,13 @@ import 'package:sandbox/common/common.dart';
 import 'package:sandbox/stories/ball/basic_ball_game.dart';
 
 class SparkyBumperGame extends BasicBallGame with Traceable {
-  SparkyBumperGame({
-    required bool trace,
-  })  : _trace = trace,
-        super(color: const Color(0xFF0000FF));
+  SparkyBumperGame() : super(color: const Color(0xFF0000FF));
 
   static const info = '''
     Shows how a SparkyBumper is rendered.
 
     Activate the "trace" parameter to overlay the body.
 ''';
-
-  final bool _trace;
-
-  @override
-  bool get trace => _trace;
 
   @override
   Future<void> onLoad() async {

--- a/packages/pinball_components/sandbox/lib/stories/sparky_bumper/stories.dart
+++ b/packages/pinball_components/sandbox/lib/stories/sparky_bumper/stories.dart
@@ -7,9 +7,7 @@ void addSparkyBumperStories(Dashbook dashbook) {
   dashbook.storiesOf('Sparky Bumpers').add(
         'Basic',
         (context) => GameWidget(
-          game: SparkyBumperGame(
-            trace: context.boolProperty('Trace', true),
-          ),
+          game: SparkyBumperGame()..trace = context.boolProperty('Trace', true),
         ),
         codeLink: buildSourceLink('sparky_bumper/basic.dart'),
         info: SparkyBumperGame.info,


### PR DESCRIPTION
## Description

* adds `traceAllBodies` extension method on `Forge2DGame`
* refactor existing trace stories
* combine flipper stories into one to be consistent with others

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
