### PR TITLE
chore: added meta tags in index html for image preview

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -27,7 +27,7 @@
   <meta property="og:title" content="Google I/O Pinball">
 
   <!-- TODO(jonathandaniels-vgv): revisit once Google sets up deployments -->
-  <meta property="og:url" content="https://pinball.flutter.dev">
+  <meta property="og:url" content="https://flutter.dev">
 
   <!-- TODO(jonathandaniels-vgv): swap this image with updated pinball image -->
   <meta name="twitter:image"


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Added the needed meta tags inside the index.html to show a preview image when sharing the pinball link. Right now the placeholder is using photobooth, and will need to update the image url with pinball once we have the assets

<img width="1489" alt="Screen Shot 2022-04-26 at 1 22 02 PM" src="https://user-images.githubusercontent.com/102978796/165387366-c2a5cfd1-3ebc-49c2-8f8d-edaea6a1ac4b.png">

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

