### PR TITLE
fix: ball gravity

### DIFF
--- a/packages/pinball_components/lib/src/components/ball.dart
+++ b/packages/pinball_components/lib/src/components/ball.dart
@@ -115,7 +115,7 @@ class Ball<T extends Forge2DGame> extends BodyComponent<T>
       math.pow(defaultGravity, 2) - math.pow(positionalXForce, 2),
     );
 
-    body.gravityOverride = Vector2(positionalXForce, positionalYForce);
+    body.gravityOverride = Vector2(-positionalXForce, positionalYForce);
   }
 }
 


### PR DESCRIPTION
## Description

There must have been a change in the gravity override x-direction because the ball is moving opposite of how it use to.

This is the behavior on the current main.
![CleanShot 2022-04-30 at 15 58 11](https://user-images.githubusercontent.com/77211884/166126107-ab9af13f-c139-4732-89fb-1e41bfbd582e.gif)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
