### PR TITLE
Chore: Update copy of mobile how to play screen

### DIFF
--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -20,7 +20,7 @@
   "@flipperControls": {
     "description": "Text displayed on the how to play dialog with the flipper controls"
   },
-  "tapAndHoldRocket": "Tap & Hold Rocket",
+  "tapAndHoldRocket": "Tap Rocket",
   "@tapAndHoldRocket": {
     "description": "Text displayed on the how to launch on mobile"
   },


### PR DESCRIPTION
## Description

Update how to play screen for mobile to say "Tap Rocket" instead of "Tap & Hold Rocket" due to recent control change from Jochum. 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
