### PR TITLE
ci: remove trailing slash from flame git references

### DIFF
--- a/packages/pinball_components/pubspec.yaml
+++ b/packages/pinball_components/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flame: ^1.1.1
   flame_forge2d:
     git:
-      url: https://github.com/flame-engine/flame/
+      url: https://github.com/flame-engine/flame
       path: packages/flame_forge2d/
       ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
   flutter:

--- a/packages/pinball_components/sandbox/pubspec.lock
+++ b/packages/pinball_components/sandbox/pubspec.lock
@@ -112,7 +112,7 @@ packages:
       path: "packages/flame_forge2d"
       ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
       resolved-ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
-      url: "https://github.com/flame-engine/flame/"
+      url: "https://github.com/flame-engine/flame"
     source: git
     version: "0.11.0"
   flutter:

--- a/packages/pinball_components/sandbox/pubspec.yaml
+++ b/packages/pinball_components/sandbox/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flame: ^1.1.1
   flame_forge2d:
     git: 
-      url: https://github.com/flame-engine/flame/
+      url: https://github.com/flame-engine/flame
       path: packages/flame_forge2d/
       ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
   flutter:

--- a/packages/pinball_flame/pubspec.yaml
+++ b/packages/pinball_flame/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flame: ^1.1.1
   flame_forge2d:
     git: 
-      url: https://github.com/flame-engine/flame/
+      url: https://github.com/flame-engine/flame
       path: packages/flame_forge2d/
       ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
   flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,7 +245,7 @@ packages:
       path: "packages/flame_forge2d"
       ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
       resolved-ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
-      url: "https://github.com/flame-engine/flame/"
+      url: "https://github.com/flame-engine/flame"
     source: git
     version: "0.11.0"
   flame_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flame_bloc: ^1.4.0
   flame_forge2d:
     git:
-      url: https://github.com/flame-engine/flame/
+      url: https://github.com/flame-engine/flame
       path: packages/flame_forge2d/
       ref: a50d4a1e7d9eaf66726ed1bb9894c9d495547d8f
   flutter:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- ci: remove trailing slash from flame git references
  - technically trailing slash is incorrect and it looks like newer version of the Git CLI ignore it but I'm on `git version 2.30.1 (Apple Git-130)` and when I try to install dependencies via `flutter packages get` the process fails and continues to retry indefinitely

```
Please make sure you have the correct access rights
and the repository exists.
exit code: 128
pub get failed (server unavailable) -- attempting retry 3 in 4 seconds...
Git error. Command: `git clone --mirror https://github.com/flame-engine/flame/ /Users/felix/.pub-cache/git/cache/flame-d0e0e44e7eb1384b043a0733c26ffc6c065869a6`
stdout: 
stderr: Cloning into bare repository '/Users/felix/.pub-cache/git/cache/flame-d0e0e44e7eb1384b043a0733c26ffc6c065869a6'...
ERROR: Repository not found.
fatal: Could not read from remote repository.
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
