### PR TITLE
fix: zoom level for plunger

### DIFF
--- a/lib/game/behaviors/camera_focusing_behavior.dart
+++ b/lib/game/behaviors/camera_focusing_behavior.dart
@@ -51,7 +51,7 @@ class CameraFocusingBehavior extends Component
           position: _foci[GameStatus.waiting]?.position ?? Vector2(0, -112),
         ),
         GameStatus.playing: _FocusData(
-          zoom: size.y / 165,
+          zoom: size.y / 160,
           position: _foci[GameStatus.playing]?.position ?? Vector2(0, -7.8),
         ),
         GameStatus.gameOver: _FocusData(


### PR DESCRIPTION
## Description

* zooms in so the plunger is not visible at the bottom

https://user-images.githubusercontent.com/77211884/167525680-cb77c45a-3d8f-4fe1-9719-ad2ae560d8ef.mp4

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
