### PR TITLE
fix: Firestore Security Rules Vulnerabilities

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -26,7 +26,8 @@ service cloud.firestore {
       // A leaderboard entry can be created if the user is authenticated,
       // it's 3 characters long, and not a prohibited combination.
       allow create: if isAuthedUser(request.auth) &&
-                       inCharLimit(request.resource.data.playerInitials) && 
+                       inCharLimit(request.resource.data.playerInitials) &&
+                       isValidCharacter(request.resource.data.character) &&
                        !prohibited(request.resource.data.playerInitials);
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,7 +9,11 @@ service cloud.firestore {
       }
       
       function inCharLimit(initials) {
-        return initials.size() < 4;
+        return initials.size() == 3;
+      }
+
+      function isValidCharacter(character) {
+        return character == 'android' || character == 'dash' || character == 'dino' || character == 'sparky';
       }
       
       function isAuthedUser(auth) {


### PR DESCRIPTION
## Description

There was an issue in the security rules that allowed:

1. Passing `playerInitials` with less than 3 characters (which is not intended).
2. Passing an **invalid** or **no** `character` (which breaks the leaderboards completely).

The second one is severe because the app will display that there is no connection and the leaderboards cannot be fetched (due to an error in parsing).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
