### PR TITLE
fix: avoid Ball tuneling Flipper at high speed

### DIFF
--- a/packages/pinball_components/lib/src/components/ball/ball.dart
+++ b/packages/pinball_components/lib/src/components/ball/ball.dart
@@ -63,6 +63,7 @@ class Ball extends BodyComponent with Layered, InitialPosition, ZIndex {
       position: initialPosition,
       type: BodyType.dynamic,
       userData: this,
+      bullet: true,
     );
 
     return world.createBody(bodyDef)..createFixtureFromShape(shape, 1);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Sets the `Ball` body to a bullet to avoid tunnelling through the Flipper when moving at high speeds.

Note: This requires play-testing. Setting a body to a bullet in Forge2D increases processing time. We could alternatively, set the Flipper's body to be a bullet, however, it is usually recommended to set the bullet flag to the fastest moving dynamic body.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
