### PR TITLE
fix: Add restitution to Ball

### DIFF
--- a/packages/pinball_components/lib/pinball_components.dart
+++ b/packages/pinball_components/lib/pinball_components.dart
@@ -1,4 +1,5 @@
 library pinball_components;
 
 export 'gen/gen.dart';
-export 'src/pinball_components.dart';
+export 'src/components/components.dart';
+export 'src/extensions/extensions.dart';

--- a/packages/pinball_components/lib/src/components/ball/ball.dart
+++ b/packages/pinball_components/lib/src/components/ball/ball.dart
@@ -66,7 +66,13 @@ class Ball extends BodyComponent with Layered, InitialPosition, ZIndex {
       bullet: true,
     );
 
-    return world.createBody(bodyDef)..createFixtureFromShape(shape, 1);
+    final fixtureDef = FixtureDef(
+      shape,
+      restitution: 0.35,
+      density: 1,
+    );
+
+    return world.createBody(bodyDef)..createFixture(fixtureDef);
   }
 
   /// Immediately and completely [stop]s the ball.

--- a/packages/pinball_components/lib/src/components/multiball/multiball.dart
+++ b/packages/pinball_components/lib/src/components/multiball/multiball.dart
@@ -1,9 +1,9 @@
 import 'dart:math' as math;
+
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
-import 'package:pinball_components/gen/assets.gen.dart';
+import 'package:pinball_components/pinball_components.dart';
 import 'package:pinball_components/src/components/multiball/behaviors/behaviors.dart';
-import 'package:pinball_components/src/pinball_components.dart';
 import 'package:pinball_flame/pinball_flame.dart';
 
 export 'cubit/multiball_cubit.dart';

--- a/packages/pinball_components/lib/src/pinball_components.dart
+++ b/packages/pinball_components/lib/src/pinball_components.dart
@@ -1,2 +1,0 @@
-export 'components/components.dart';
-export 'extensions/extensions.dart';

--- a/packages/pinball_components/test/src/components/multiball/cubit/multiball_state_test.dart
+++ b/packages/pinball_components/test/src/components/multiball/cubit/multiball_state_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pinball_components/src/pinball_components.dart';
+import 'package:pinball_components/pinball_components.dart';
 
 void main() {
   group('MultiballState', () {

--- a/packages/pinball_components/test/src/components/multiplier/cubit/multiplier_state_test.dart
+++ b/packages/pinball_components/test/src/components/multiplier/cubit/multiplier_state_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pinball_components/src/pinball_components.dart';
+import 'package:pinball_components/pinball_components.dart';
 
 void main() {
   group('MultiplierState', () {


### PR DESCRIPTION
## Description

This adds some restitution to the ball (this means that it will bounce off things) which makes the physics simulation look a bit more realistic. Currently when it hits the pads for example the ball just stops, which looks a bit unnatural.

Preferably I would like to have changed the friction of the ball not to be 0 too, but since the rendering currently depends on the direction of the ball and the 0 friction is used to ensure that the ball doesn't rotate that is a much bigger change.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
