### PR TITLE
lock flame version

### DIFF
--- a/packages/pinball_components/pubspec.yaml
+++ b/packages/pinball_components/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   bloc: ^8.0.3
-  flame: ^1.1.1
+  flame: 1.1.1
   flame_bloc: ^1.4.0
   flame_forge2d:
     git:

--- a/packages/pinball_components/sandbox/pubspec.yaml
+++ b/packages/pinball_components/sandbox/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   dashbook: ^0.1.7
-  flame: ^1.1.1
+  flame: 1.1.1
   flame_bloc: ^1.4.0
   flame_forge2d:
     git: 

--- a/packages/pinball_flame/pubspec.yaml
+++ b/packages/pinball_flame/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   bloc: ^8.0.0
-  flame: ^1.1.1
+  flame: 1.1.1
   flame_bloc: ^1.4.0
   flame_forge2d:
     git: 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,9 @@ environment:
   sdk: ">=2.16.0 <3.0.0"
   flutter: 2.10.5
 
+dependency_overrides: 
+  flame: 1.1.1
+  
 dependencies:
   authentication_repository:
     path: packages/authentication_repository

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,9 +6,6 @@ publish_to: none
 environment:
   sdk: ">=2.16.0 <3.0.0"
   flutter: 2.10.5
-
-dependency_overrides: 
-  flame: 1.1.1
   
 dependencies:
   authentication_repository:
@@ -18,7 +15,7 @@ dependencies:
   equatable: ^2.0.3
   firebase_auth: ^3.3.16
   firebase_core: ^1.15.0
-  flame: ^1.1.1
+  flame: 1.1.1
   flame_bloc: ^1.4.0
   flame_forge2d:
     git:


### PR DESCRIPTION

## Description

Lock flame version to 1.1.1 because class ParentIsA conflicts in 1.2.0

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
